### PR TITLE
Fix pipeline eval

### DIFF
--- a/slue_toolkit/eval/eval_utils.py
+++ b/slue_toolkit/eval/eval_utils.py
@@ -24,7 +24,7 @@ def get_ner_scores(all_gt, all_predictions):
         all_gt: [(GPE, "eu", 0), (DATE, "today", 0), (GPE, "eu", 1)]
     """
     metrics = {}
-    stats = get_stats(all_gt, all_predictions)
+    stats = get_ner_stats(all_gt, all_predictions)
     num_correct, num_gt, num_pred = 0, 0, 0
     prec_lst, recall_lst, fscore_lst = [], [], []
     for tag_name, tag_stats in stats.items():

--- a/slue_toolkit/text_ner/ner_deberta.py
+++ b/slue_toolkit/text_ner/ner_deberta.py
@@ -27,12 +27,14 @@ def eval(
     model_type,
     eval_asr=False,
     eval_subset="dev",
+    train_label="raw",
     eval_label="combined",
     lm="nolm",
     asr_model_type="w2v2-base",
     save_results=False,
 ):
     log_dir = os.path.join(model_dir, "metrics")
+    label_list = read_lst(os.path.join(data_dir, f"{train_label}_tag_lst_ordered"))
     if save_results:
         ner_results_dir = os.path.join(log_dir, "error_analysis")
     os.makedirs(log_dir, exist_ok=True)
@@ -46,14 +48,13 @@ def eval(
         "fine-tune", "combined", get_map_files=True
     )  # prepare tag-id mapping files
 
-    tag2id = load_pkl(os.path.join(data_dir, "raw_tag2id.pkl"))
     if "combined" in eval_label:
         tag_lst = read_lst(os.path.join(data_dir, "combined_tag_lst_ordered"))
 
-    val_texts, val_tags, _, _, _, _ = data_obj.prep_data(eval_subset, tag2id=tag2id)
+    val_texts, val_tags, _, _, _, _ = data_obj.prep_data(eval_subset, "raw")
     if eval_asr:
         asr_val_texts, _, _, _, asr_val_dataset = data_obj.prep_data(
-            f"{eval_subset}-{asr_model_type}-asr-{lm}", tag2id
+            f"{eval_subset}-{asr_model_type}-asr-{lm}", "raw"
         )
     else:
         asr_val_texts, asr_val_dataset = None, None

--- a/slue_toolkit/text_ner/ner_deberta_modules.py
+++ b/slue_toolkit/text_ner/ner_deberta_modules.py
@@ -1,3 +1,4 @@
+from curses import raw
 import logging,os,re
 logger = logging.getLogger(__name__)
 import numpy as np
@@ -16,7 +17,8 @@ from transformers import (
 	DebertaForTokenClassification
 )
 from transformers.trainer_utils import get_last_checkpoint
-from slue_toolkit.generic_utils import read_lst, write_to_file, load_pkl, save_pkl
+from slue_toolkit.generic_utils import write_to_file, load_pkl, save_pkl
+from slue_toolkit.eval import eval_utils
 
 class VPDataset(torch.utils.data.Dataset):
 	def __init__(self, encodings, labels):
@@ -40,6 +42,10 @@ class DataSetup():
 		file_path = Path(os.path.join(self.data_dir, file_path))
 
 		raw_text = file_path.read_text().strip()
+		# Space separating trailing "'s" in accordance with the slue voxpopuli NER post processing step.
+		# This avoids over-penalizing the model just because the LM used for ASR decoding might not 
+		# be trained on the text that is similarly post-processed.
+		raw_text = [line.replace("'s", " 's").replace("  ", " ") for line in raw_text]
 		raw_docs = re.split(r'\n\t?\n', raw_text)
 		token_docs = []
 		tag_docs = []
@@ -274,27 +280,13 @@ class Eval():
 	def reduce(self, entity_name):
 		return entity_name.split("-")[-1]
 
-	def handling_apostrophe(self, entity_info):
-		"""
-		Handling trailing "'s" and separating it from the entity phrase
-		in accordance with the vox populi NER post processing step.
-		This avoids over-penalizing the model just because the LM used
-		for ASR decoding might not be trained on the text that is similarly
-		post-processed.
-		"""
-		entity_phrase = " ".join(entity_info).replace("'s", " 's").replace("  ", " ")
-		if entity_phrase[-3:] == " 's":
-			entity_phrase = entity_phrase[:-3]
-		return entity_phrase
-
 	def update_entity_lst(self, lst, entity_name, score_type, entity_info):
 		"""
 		entity_info: word segment when eval_asr is True and word location otherwise
 		"""
 		if self.eval_asr:
 			if score_type == "standard":
-				entity_phrase = self.handling_apostrophe(entity_info)
-				lst.append((self.reduce(entity_name), entity_phrase))
+				lst.append((self.reduce(entity_name), " ".join(entity_info)))
 			elif score_type == "label":
 				lst.append((self.reduce(entity_name), "word"))
 		else:
@@ -459,11 +451,13 @@ class Eval():
 	def get_scores(self, score_type, eval_dataset_pred, eval_texts_gt, eval_tags_gt=None, eval_texts_pred=None):
 		all_gt, all_predictions = self.run_inference(score_type, eval_dataset_pred, eval_texts_gt, eval_tags_gt, eval_texts_pred)
 
-		metrics_dct = eval_utils.get_scores(all_gt, all_predictions)
-		print("[%s, micro-averaged %s] Precision: %.2f, recall: %.2f, fscore = %.2f" % (
-			tag_name, res_dct["precision"], res_dct["recall"], res_dct["fscore"]))
+		metrics_dct = eval_utils.get_ner_scores(all_gt, all_predictions)
+		print("[micro-averaged F1] Precision: %.2f, recall: %.2f, fscore = %.2f" % (
+			metrics_dct["overall_micro"]["precision"], 
+			metrics_dct["overall_micro"]["recall"], 
+			metrics_dct["overall_micro"]["fscore"]))
 
 		if score_type == "standard": # with standard evaluation only
-			analysis_examples_dct = eval_utils.error_analysis(all_labels, all_predictions, eval_texts_gt)
+			analysis_examples_dct = eval_utils.ner_error_analysis(all_gt, all_predictions, eval_texts_gt)
 
 		return metrics_dct, analysis_examples_dct

--- a/slue_toolkit/text_ner/ner_deberta_modules.py
+++ b/slue_toolkit/text_ner/ner_deberta_modules.py
@@ -274,13 +274,27 @@ class Eval():
 	def reduce(self, entity_name):
 		return entity_name.split("-")[-1]
 
+	def handling_apostrophe(self, entity_info):
+		"""
+		Handling trailing "'s" and separating it from the entity phrase
+		in accordance with the vox populi NER post processing step.
+		This avoids over-penalizing the model just because the LM used
+		for ASR decoding might not be trained on the text that is similarly
+		post-processed.
+		"""
+		entity_phrase = " ".join(entity_info).replace("'s", " 's").replace("  ", " ")
+		if entity_phrase[-3:] == " 's":
+			entity_phrase = entity_phrase[:-3]
+		return entity_phrase
+
 	def update_entity_lst(self, lst, entity_name, score_type, entity_info):
 		"""
 		entity_info: word segment when eval_asr is True and word location otherwise
 		"""
 		if self.eval_asr:
 			if score_type == "standard":
-				lst.append((self.reduce(entity_name), " ".join(entity_info)))
+				entity_phrase = self.handling_apostrophe(entity_info)
+				lst.append((self.reduce(entity_name), entity_phrase))
 			elif score_type == "label":
 				lst.append((self.reduce(entity_name), "word"))
 		else:


### PR DESCRIPTION
Space separating "'s" in the entity phrases in the ASR output before evaluating it for NER. This is in accordance with the slue voxpopuli NER data processing, which might not necessarily be followed by the LM used for ASR decoding.

And minor bug fixes.