### PR TITLE
refine text NER eval

### DIFF
--- a/baselines/ner/README.md
+++ b/baselines/ner/README.md
@@ -38,7 +38,7 @@ The above command can also be used to train `deberta-large` model and also accep
 #### Evaluation of NLP Topline
 The following command evaluates the trained deberta-base model on dev set with combined labels
 ```sh
-bash baselines/ner/nlp_scripts/eval-deberta.sh deberta-base dev combined
+bash baselines/ner/nlp_scripts/eval-deberta.sh deberta-base dev raw combined
 ```
 
 #### Training the Pipeline model

--- a/baselines/ner/nlp_scripts/eval-deberta.sh
+++ b/baselines/ner/nlp_scripts/eval-deberta.sh
@@ -1,12 +1,14 @@
 model_type=$1
 eval_set=$2
-eval_label=$3
+train_label=$3
+eval_label=$4
 
 python slue_toolkit/text_ner/ner_deberta.py eval \
 --data_dir manifest/slue-voxpopuli/nlp_ner \
---model_dir save/nlp_ner/${model_type} \
+--model_dir save/nlp_ner/${model_type}_${train_label} \
 --model_type $model_type \
 --eval_asr False \
---eval_subset $eval_set \
+--train_label $train_label \
 --eval_label $eval_label \
---save_results True
+--eval_subset $eval_set \
+--save_results True 

--- a/baselines/ner/nlp_scripts/ft-deberta.sh
+++ b/baselines/ner/nlp_scripts/ft-deberta.sh
@@ -3,6 +3,6 @@ label_type=$2
 
 python slue_toolkit/text_ner/ner_deberta.py train \
 --data_dir manifest/slue-voxpopuli/nlp_ner \
---model_dir save/nlp_ner/${model_type} \
+--model_dir save/nlp_ner/${model_type}_${label_type} \
 --model_type $model_type \
 --label_type $label_type

--- a/slue_toolkit/text_ner/ner_deberta.py
+++ b/slue_toolkit/text_ner/ner_deberta.py
@@ -40,7 +40,6 @@ def eval(
     os.makedirs(log_dir, exist_ok=True)
 
     data_obj = NDM.DataSetup(data_dir, model_type)
-    label_list = read_lst(os.path.join(data_dir, f"{eval_label}_tag_lst_ordered"))
 
     val_texts, val_tags, _, _, val_dataset = data_obj.prep_data(
         eval_subset, train_label
@@ -51,9 +50,7 @@ def eval(
         )
     else:
         asr_val_texts = None
-    eval_obj = NDM.Eval(
-        data_dir, model_dir, model_type, label_list, eval_label, eval_asr
-    )
+    eval_obj = NDM.Eval(data_dir, model_dir, train_label, eval_label, eval_asr)
     for score_type in ["standard", "label"]:
         if eval_asr:
             res_fn = "-".join(


### PR DESCRIPTION
Cleaned up and made the text NER evaluation more generic. Previously it wasn't correctly handling the case where the model is fine-tuned and evaluated both on the combined label set. Now it does and resolves issue #16.