### PR TITLE
Clean-up

### DIFF
--- a/slue_toolkit/prepare/data_utils.py
+++ b/slue_toolkit/prepare/data_utils.py
@@ -1,5 +1,5 @@
 from slue_toolkit.generic_utils import raw_to_combined_tag_map
-
+import ast
 
 def remove_punc(sent):
     """
@@ -20,12 +20,9 @@ def get_label_lst(label_str, label_type):
         return []
     tag_map = raw_to_combined_tag_map
     label_lst = []
-    ner_labels_lst = label_str.strip("[[").strip("]]").split("], [")
+    ner_labels_lst = ast.literal_eval(label_str)
     for item in ner_labels_lst:
-        label, start_id, length = item.split(", ")
-        label = label[1:-1]
-        start_id = int(start_id)
-        length = int(length)
+        label, start_id, length = item
         if label_type == "combined":
             if tag_map[label] != "DISCARD":
                 label_lst.append((tag_map[label], start_id, length))

--- a/slue_toolkit/prepare/prepare_voxpopuli.py
+++ b/slue_toolkit/prepare/prepare_voxpopuli.py
@@ -99,7 +99,7 @@ def create_manifest(
                         print(ltr_str, file=f_ltr)
         e2e_ner_tsv_fn = os.path.join(manifest_dir, f"e2e_ner/{split}.tsv")
         if not os.path.exists(e2e_ner_tsv_fn):
-            os.symlink(f"../{split}.tsv", e2e_ner_tsv_fn)
+            os.symlink(f"{manifest_dir}/{split}.tsv", e2e_ner_tsv_fn)
 
     for label_type in ["raw", "combined"]:
         tag2id, id2tag, tag_lst_ordered = data_utils.prepare_tag_id_mapping(label_type)


### PR DESCRIPTION
Modify `get_label_lst()` implementation in `slue_toolkit/prepare/data_utils.py`. The function produces exactly the same output as before but with a cleaner implementation using the `ast` library.